### PR TITLE
Allow to specify control position

### DIFF
--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -16,6 +16,10 @@ export default {
   inject: ["mapbox", "map"],
 
   props: {
+    position: {
+      type: String,
+      default: "top-right"
+    },
     // Mapbox-geocoder options
     accessToken: {
       type: String,
@@ -119,7 +123,7 @@ export default {
 
   methods: {
     $_deferredMount() {
-      this.map.addControl(this.control);
+      this.map.addControl(this.control, this.position);
       if (this.input) {
         this.control.setInput(this.input);
       }


### PR DESCRIPTION
Currently this control does not allow to set its position inside the map frame.
This simple change allows for this behavior.