### PR TITLE
Added custom container support from @tpaksu branch and control positioning support from @lucadegasperi branch.

### DIFF
--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -20,6 +20,10 @@ export default {
       type: String,
       default: "top-right"
     },
+    container: {
+        type: String,
+        default: null
+    },
     // Mapbox-geocoder options
     accessToken: {
       type: String,
@@ -123,8 +127,12 @@ export default {
 
   methods: {
     $_deferredMount() {
-      this.map.addControl(this.control, this.position);
-      if (this.input) {
+        if(this.container !== null){
+            document.getElementById(this.container).appendChild(this.control.onAdd(this.map))
+        }else{
+            this.map.addControl(this.control, this.position);
+        }
+    if (this.input) {
         this.control.setInput(this.input);
       }
       this.$_emitEvent("added", { geocoder: this.control });

--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -16,6 +16,10 @@ export default {
   inject: ["mapbox", "map"],
 
   props: {
+    position: {
+      type: String,
+      default: "top-right"
+    },
     // Mapbox-geocoder options
     accessToken: {
       type: String,
@@ -119,7 +123,7 @@ export default {
 
   methods: {
     $_deferredMount() {
-      this.map.addControl(this.control);
+      this.map.addControl(this.control, this.position);
       if (this.input) {
         this.control.setInput(this.input);
       }


### PR DESCRIPTION
With this pull, the plugin will have the option to place the input in another container element in the page or a different position on the owner map. 

Usage: 

```
<MglGeocoderControl
            :accessToken="accessToken"
            @results="handleSearch"
            container="geocoder_input_container"
            position="top-left"
        />
```

**container:** the id of the container element to put the input in. 
**position:** the position within the map boundaries, 

*Note: Can't be used together with container option. Container will override position.*
