### PR TITLE
fix "No mapboxgl detected in options" error

### DIFF
--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -73,6 +73,10 @@ export default {
       type: Function,
       default: null
     },
+    mapboxgl: {
+      type: Object,
+      default: null,
+    },
     // Component options
     input: {
       type: String,


### PR DESCRIPTION
Fix error `No mapboxgl detected in options. Map markers are disabled. Please set options.mapboxgl.` by providing `mapboxgl` prop.
Based on issue https://github.com/mapbox/mapbox-gl-geocoder/issues/252