### PR TITLE
Fix console error by passing mapboxgl in options

### DIFF
--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -107,7 +107,10 @@ export default {
     if (this.accessToken && !this.mapbox.accessToken) {
       this.mapbox.accessToken = this.accessToken;
     }
-    this.control = new MapboxGeocoder(this.$props);
+    this.control = new MapboxGeocoder({
+      ...this.$props,
+      mapboxgl: this.mapbox,
+    });
     this.control.on("results", this.$_updateInput);
 
     this.$_deferredMount();


### PR DESCRIPTION
Every time we mount this component, we get this error:

![image](https://user-images.githubusercontent.com/431220/95672358-6e694e00-0ba0-11eb-82b4-5755df2b9d8d.png)

This patch makes the error go away.

Note: Except for the error message, I haven't noticed anything not working correctly.