### PR TITLE
bug: geocoder limit to countries

### DIFF
--- a/src/GeocoderControl.js
+++ b/src/GeocoderControl.js
@@ -49,7 +49,7 @@ export default {
       type: String,
       default: null
     },
-    country: {
+    countries: {
       type: String,
       default: null
     },
@@ -151,7 +151,7 @@ export default {
     query(query) {
       if (this.control) {
         this.$emit("update:input", query);
-        return this.contol.query(query);
+        return this.control.query(query);
       }
       return null;
     }


### PR DESCRIPTION
1. Your spelling mistake
2. `country` to be changed into `countries`

Reference:
`https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-geocoder-limit-region/`